### PR TITLE
prevent back button when modal close is attempted

### DIFF
--- a/js/views/shared.js
+++ b/js/views/shared.js
@@ -1,3 +1,11 @@
+window.onbeforeunload(function() {
+  var modal = document.getElementById("modal");
+  if (m.classList.contains("shown")) {
+    toggleModal();
+    // TODO: prevent backwards movement in browser history in this case.
+  }
+});
+
 function toggleModal(modal) {
   var m = modal || document.getElementById("modal");
   var body = document.getElementsByTagName("body")[0];


### PR DESCRIPTION
Some users are clicking the BACK BUTTON instead of the BIG WHITE X on the modal popup.

Is there a way to help them close the modal instead of navigating back? I put in the psuedocode I think will work, need some advice.